### PR TITLE
Adds ssl parameter to db config

### DIFF
--- a/lib/conjoin/active_record.rb
+++ b/lib/conjoin/active_record.rb
@@ -51,6 +51,15 @@ module Conjoin
           wait_timeout: 2147483
         }
       }
+      if db.scheme == 'mysql2' && db.query
+        ssl_hash = db.query.split('&').map{|c| [c.split('=')[0],c.split('=')[1]] }.to_h
+        mysql_ssl = {
+          sslca: ssl_hash['sslca'],
+          sslcert: ssl_hash['sslcert'],
+          sslkey: ssl_hash['sslkey']
+        }
+        ActiveRecord::Base.configurations['default'] = ActiveRecord::Base.configurations['default'].merge(mysql_ssl)
+      end
 
       ActiveRecord::Base.establish_connection(:default)
     end

--- a/lib/conjoin/tasks/migrate.rb
+++ b/lib/conjoin/tasks/migrate.rb
@@ -139,6 +139,15 @@ module ActiveRecordTasks
       username: db.user,
       password: db.password
     }
+    if db.scheme == 'mysql2' && db.query
+      ssl_hash = db.query.split('&').map{|c| [c.split('=')[0],c.split('=')[1]] }.to_h
+      mysql_ssl = {
+        sslca: ssl_hash['sslca'],
+        sslcert: ssl_hash['sslcert'],
+        sslkey: ssl_hash['sslkey']
+      }
+      ActiveRecord::Base.configurations['default'] = ActiveRecord::Base.configurations['default'].merge(mysql_ssl)
+    end
   end
 
   def connect_to_active_record


### PR DESCRIPTION
#### what?

when the adapter is mysql2 look for ssl params, parsed and merge into db config

#### why are we using a manual parser instead of ActiveRecord?

In the current ActiveRecord version there is an issue this team faced and reported to rails team, they fixed but it didn't make it to a support version that other local dependencies can support.
https://github.com/rails/rails/issues/14495